### PR TITLE
Add ability to query pumphistory from a specific record id.

### DIFF
--- a/cmd/pumphistory/openaps.jq
+++ b/cmd/pumphistory/openaps.jq
@@ -25,7 +25,8 @@ def duration_to_minutes:
   # and the type, which is the same as the decocare type in many cases.
   {
     timestamp: .Time,
-    _type: .Type
+    _type: .Type,
+    id: .Data
   } +
   # Add type-specific fields.
   if .Type == "TempBasalDuration" then


### PR DESCRIPTION
Querying by timestamp is sometimes racy because some records have the
same timestamp such as Bolus and BolusWizard.
Also the timestamps are not always monotonically increasing when the
clock has been changed.

Being able to query the pumphistory from a specific record id avoids
these race conditions.