### PR TITLE
Change sensorCalibrationFactor to avoid issues

### DIFF
--- a/cmd/bgproxy/main.go
+++ b/cmd/bgproxy/main.go
@@ -16,7 +16,7 @@ const (
 	sensorInterval1 = 15 * time.Second
 	sensorCycle     = sensorInterval0 + sensorInterval1
 
-	sensorCalibrationFactor = 10
+	sensorCalibrationFactor = 3
 )
 
 var (


### PR DESCRIPTION
A Enlite sensor counts as defective if the ISIG falls below 10. To avoid sensor error alarms and calibration issues the sent ISIG should not fall below this value. Therefore I suggest to change the divider from 10 to 3.